### PR TITLE
Bug color selection in scrolled window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All changes to Vue Color Picker Wheel will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 16-01-2019
+### Fixed
+- Color selection (circle) widget not following mouseclicks and touches on mobile correctly (fixes issue #9)
+
 ## [0.4.1] - 16-11-2018
 ### Fixed
 - Prevent color picker from being highlighted (showing a black overlay) on touch devices when tapping (and holding)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-color-picker-wheel",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-color-picker-wheel",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A Vue color picker component based on the Farbtastic jQuery Color Picker plug-in",
   "main": "dist/color-picker.umd.js",
   "module": "dist/color-picker.esm.js",

--- a/src/color-picker.vue
+++ b/src/color-picker.vue
@@ -387,8 +387,8 @@
             },
             widgetCoords(event) {
                 return {
-                    x: event.pageX - this.offset.left - this.mid,
-                    y: event.pageY - this.offset.top - this.mid
+                    x: event.clientX - this.offset.left - this.mid,
+                    y: event.clientY - this.offset.top - this.mid
                 };
             },
             mousedown(event) {
@@ -507,8 +507,8 @@
              */
             widgetCoordsTouch(event) {
                 return {
-                    x: event.targetTouches[0].pageX - this.offset.left - this.mid,
-                    y: event.targetTouches[0].pageY - this.offset.top - this.mid
+                    x: event.targetTouches[0].clientX - this.offset.left - this.mid,
+                    y: event.targetTouches[0].clientY - this.offset.top - this.mid
                 };
             },
             /**


### PR DESCRIPTION
Fixes https://github.com/stijlbreuk/vue-color-picker-wheel/issues/9 by using clientX and clientY properties to determine where the user clicked or touched.